### PR TITLE
トップページたびびと一覧のIDズレ修正

### DIFF
--- a/apps/wordpress/htdocs/wp-content/themes/welcart_basic-square/front-page.php
+++ b/apps/wordpress/htdocs/wp-content/themes/welcart_basic-square/front-page.php
@@ -95,7 +95,7 @@ wp_reset_postdata();
 
 
 <!-- 旅人一覧 -->
-<?php $traveller_ids = array( 7, 18, 39, 42 ); // カテゴリーID ?>
+<?php $traveller_ids = array( 7, 36, 47, 52 ); // カテゴリーID ?>
 <?php if ( ! empty( $traveller_ids ) ) : ?>
 <div class="top-travellers">
 	<p class="contents-title">たびびと一覧</p>


### PR DESCRIPTION
## 概要
0004＿0003 TOPへの商品一覧・インフルエンサーページリンクの表示
https://github.com/sakukei/rite/issues/3
- 

## 変更内容
トップページのたびびと一覧のIDのズレを修正しました。
- 

## その他
- 
