### PR TITLE
トップページの旅人一覧の位置変更 / 商品一覧ページの見出し削除、高さ固定値で調整 / トップページのスマホ時のたびびと一覧とピックアップ…

### DIFF
--- a/apps/wordpress/htdocs/wp-content/themes/welcart_basic-square/category.php
+++ b/apps/wordpress/htdocs/wp-content/themes/welcart_basic-square/category.php
@@ -40,8 +40,8 @@ get_header(); ?>
                       <?php
                       echo $term_img;
                       echo $term_before;
-                      the_archive_title('<h1 class="page-title">', '</h1>');
-                      the_archive_description('<div class="taxonomy-description">', '</div>');
+                      // the_archive_title('<h1 class="page-title">', '</h1>');
+                      // the_archive_description('<div class="taxonomy-description">', '</div>');
                       echo $term_after;
                       ?>
                     </div><!-- .page-header -->

--- a/apps/wordpress/htdocs/wp-content/themes/welcart_basic-square/front-page.php
+++ b/apps/wordpress/htdocs/wp-content/themes/welcart_basic-square/front-page.php
@@ -68,7 +68,7 @@ $item_query = new WP_Query(
 <?php if ( $item_query->have_posts() ) : ?>
 	<div class="top-items">
 		<p class="contents-title">商品一覧</p>
-		<div class="row row-38">
+		<div class="row row-0">
 		<?php
 		while ( $item_query->have_posts() ) :
 			$item_query->the_post();
@@ -86,37 +86,12 @@ $item_query = new WP_Query(
 		</article><!-- /card-item -->
 		<?php endwhile; ?>
 		</div><!-- /row -->
-		<div class="more-items"><a class="btn btn-primary" href="<?php echo esc_url( get_category_link( get_category_by_slug( 'item' )->cat_ID ) ); ?>">もっと見る</a></div>
+		<div class="more-items"><a class="btn btn-primary btn-wide-sp" href="<?php echo esc_url( get_category_link( get_category_by_slug( 'item' )->cat_ID ) ); ?>">もっと見る</a></div>
 	</div><!-- /top-items -->
 	<?php
 endif;
 wp_reset_postdata();
 ?>
-
-
-<!-- 旅人一覧 -->
-<?php $traveller_ids = array( 7, 36, 47, 52 ); // カテゴリーID ?>
-<?php if ( ! empty( $traveller_ids ) ) : ?>
-<div class="top-travellers">
-	<p class="contents-title">たびびと一覧</p>
-	<div class="row row-0">
-	<?php foreach ( $traveller_ids as $traveller_id ) : ?>
-		<?php $traveller = get_category( $traveller_id ); ?>
-	<article id="post-<?php the_ID(); ?>" <?php post_class( 'card-traveller' ); ?>>
-		<a href="<?php echo esc_url( get_category_link( $traveller_id ) ); ?>">
-			<div class="card-traveller-img" style="background: url(<?php echo esc_url( get_term_meta( $traveller_id, 'wcct-tag-thumbnail-url', true ) ); ?>) no-repeat center center / cover;">
-					<!-- <img src="<?php echo esc_url( get_term_meta( $traveller_id, 'wcct-tag-thumbnail-url', true ) ); ?>"> -->
-			</div><!-- /card-traveller-img -->
-		</a>
-		<div class="card-traveller-body">
-			<div class="card-item-title"><a href="<?php echo esc_url( get_category_link( $traveller_id ) ); ?>" rel="bookmark"><?php echo esc_html( $traveller->cat_name ); ?></a></div>
-		</div><!-- /card-traveller-body -->
-	</article><!-- /card-traveller -->
-<?php endforeach; ?>
-	</div><!-- /row -->
-</div><!-- /top-travellers -->
-<?php endif; ?>
-
 
 <!--　TOP2カラム　-->
 <div class="contents-column">
@@ -129,6 +104,30 @@ wp_reset_postdata();
 
 					<!-- TOPピックアップ記事 -->
 					<div class="top-pickup">
+
+					<!-- 旅人一覧 -->
+					<?php $traveller_ids = array( 7, 36, 47, 52 ); // カテゴリーID ?>
+					<?php if ( ! empty( $traveller_ids ) ) : ?>
+					<div class="top-travellers">
+						<p class="contents-title">たびびと一覧</p>
+						<div class="row row-0">
+						<?php foreach ( $traveller_ids as $traveller_id ) : ?>
+							<?php $traveller = get_category( $traveller_id ); ?>
+						<article id="post-<?php the_ID(); ?>" <?php post_class( 'card-traveller' ); ?>>
+							<a href="<?php echo esc_url( get_category_link( $traveller_id ) ); ?>">
+								<div class="card-traveller-img" style="background: url(<?php echo esc_url( get_term_meta( $traveller_id, 'wcct-tag-thumbnail-url', true ) ); ?>) no-repeat center center / cover;">
+										<!-- <img src="<?php echo esc_url( get_term_meta( $traveller_id, 'wcct-tag-thumbnail-url', true ) ); ?>"> -->
+								</div><!-- /card-traveller-img -->
+							</a>
+							<div class="card-traveller-body">
+								<div class="card-traveller-title"><a href="<?php echo esc_url( get_category_link( $traveller_id ) ); ?>" rel="bookmark"><?php echo esc_html( $traveller->cat_name ); ?></a></div>
+							</div><!-- /card-traveller-body -->
+						</article><!-- /card-traveller -->
+					<?php endforeach; ?>
+						</div><!-- /row -->
+					</div><!-- /top-travellers -->
+					<?php endif; ?>
+
 						<p class="contents-title">ピックアップ</p>
 						<?php
 						$count          = 0;
@@ -141,7 +140,9 @@ wp_reset_postdata();
 						);
 						?>
 						<?php
-						if ( $pickup_query->have_posts() ) :
+						if ( $pickup_query->have_posts() ) : ?>
+						<div class="row row-0">
+						<?php
 							while ( $pickup_query->have_posts() ) :
 								$pickup_query->the_post();
 								?>
@@ -175,9 +176,12 @@ wp_reset_postdata();
 								<?php
 								$count++;
 							endwhile;
+							?>
+							</div><!-- /row -->
+							<?php
 							if ( $count === $posts_per_page ) :
 								?>
-							<div id="more"><a href="#" class="btn btn-primary">もっと見る</a></div>
+							<div id="more"><a href="#" class="btn btn-primary btn-wide-sp">もっと見る</a></div>
 							<?php endif; ?>
 						<?php else : // 記事が無い場合. ?>
 							<div><p>記事はまだありません。</p></div>

--- a/apps/wordpress/htdocs/wp-content/themes/welcart_basic-square/style.css
+++ b/apps/wordpress/htdocs/wp-content/themes/welcart_basic-square/style.css
@@ -1212,7 +1212,30 @@ footer nav a {
 .blog #content article {
   /*margin: 0 0 8px;*/
   padding-bottom: 0;
-  border: none;
+	border: none;
+}
+
+.blog #content article.pickup-article {
+  /*margin: 0 0 8px;*/
+  padding-bottom: 0;
+	border: none;
+	width: 49%;
+	padding-top: 0;
+	background: #fff;
+	margin-bottom: 10px;
+}
+
+@media screen and (min-width: 62.5em) {
+
+	.blog #content article.pickup-article {
+		width: 100%;
+		background: transparent;
+		margin-bottom: 0;
+	}
+
+	.blog #content article.pickup-article + .pickup-article {
+		padding-top: 10px;
+	}
 }
 
 .grid-item {
@@ -1229,7 +1252,7 @@ footer nav a {
   -webkit-box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.22);
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.22);
   border-radius: 6px;
-  overflow: visible;
+  overflow: hidden;
 }
 
 /* - img - */
@@ -1304,8 +1327,9 @@ footer nav a {
 }
 
 .item-info-wrap .itemname {
-  height: auto;
-  margin-bottom: 10px;
+  height: 40px;
+	margin-bottom: 10px;
+	overflow: hidden;
 }
 
 .item-info-wrap .itemname a {
@@ -1317,7 +1341,8 @@ footer nav a {
   font-size: 15px;
   font-weight: bold;
   text-align: right;
-  letter-spacing: 1px;
+	letter-spacing: 1px;
+	color: #4682b4;
 }
 
 /* -- .post-info-wrap -- */
@@ -1915,13 +1940,31 @@ p.no-date {
 .pickup-content-column {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+	align-items: center;
+	flex-direction: column;
   padding-top: 10px;
 }
 
+@media screen and (min-width: 62.5em) {
+
+	.pickup-content-column {
+		flex-direction: row;
+	}
+}
+
 .pickup-content-lead {
-  width: 70%;
-  font-size: 12px;
+  width: 100%;
+	font-size: 12px;
+	margin-bottom: 10px;
+}
+
+@media screen and (min-width: 62.5em) {
+
+	.pickup-content-lead {
+		width: 70%;
+		font-size: 12px;
+		margin-bottom: 0;
+	}
 }
 
 .pickup-contributor {
@@ -3542,7 +3585,7 @@ img {
 .card-item {
 	margin: 0 0 10px;
 	padding: 0;
-	width: 100%;
+	width: 49%;
 	background: #fff;
 	box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.22);
 	border-radius: 6px;
@@ -3576,6 +3619,7 @@ img {
 	font-size: 15px;
 	font-weight: 700;
 	text-align: right;
+	color: #4682b4;
 }
 .more-items {
 	text-align: center;
@@ -3665,19 +3709,30 @@ img {
 	font-size: 12px;
 	font-weight: 700;
 }
+.btn.btn-wide-sp {
+	width: 96%;
+}
+
+@media screen and (min-width: 46.25em) {
+	.btn.btn-wide-sp {
+		width: 145px;
+	}
+}
+
 
 /* top-travellers */
 .top-travellers {
-	padding: 24px 0;
+	padding: 0;
+	margin-bottom: 24px;
 }
 
 .card-traveller {
 	margin: 0 0 10px;
-	padding: 0;
+	padding: 0 8px;
 	width: 49%;
-	background: #fff;
-	box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.22);
-	border-radius: 6px;
+	background: transparent;
+	box-shadow: none;
+	border-radius: 0;
 	overflow: hidden;
 	display: block;
 }
@@ -3688,6 +3743,7 @@ img {
 	text-align: center;
 	padding-top: 100%;
 	overflow: hidden;
+	border-radius: 100%;
 }
 .card-traveller-img:hover {
 	opacity: 0.6;
@@ -3705,6 +3761,7 @@ img {
 .card-traveller-title {
 	font-weight: 700;
 	color: #808080;
+	text-align: center;
 }
 
 @media screen and (min-width: 46.25em) {


### PR DESCRIPTION
…一覧を2列

## 概要
* トップページの旅人一覧の位置変更
* 商品一覧ページの見出し削除、高さ固定値で調整 
* トップページのスマホ時のたびびと一覧とピックアックアップ一覧を2列に

## 変更内容
### トップページPC
![toppc](https://user-images.githubusercontent.com/32994211/48944204-223fa100-ef69-11e8-95da-55fcd17494f1.jpg)

### トップページSP
![top](https://user-images.githubusercontent.com/32994211/48944216-2a97dc00-ef69-11e8-9051-58c7dcaeeda3.png)

### 商品一覧ページ
![pc](https://user-images.githubusercontent.com/32994211/48944206-266bbe80-ef69-11e8-91f9-a87151ef00a9.jpg)

## その他
- 
