### PR TITLE
トップページのピックアップ一覧の「もっと見る」ボタンを削除して全件表示

### DIFF
--- a/apps/wordpress/htdocs/wp-content/themes/welcart_basic-square/front-page.php
+++ b/apps/wordpress/htdocs/wp-content/themes/welcart_basic-square/front-page.php
@@ -131,7 +131,7 @@ wp_reset_postdata();
 						<p class="contents-title">ピックアップ</p>
 						<?php
 						$count          = 0;
-						$posts_per_page = 15;
+						$posts_per_page = -1; // 15
 						$pickup_query   = new WP_Query(
 							array(
 								'posts_per_page' => $posts_per_page, // 表示（取得）する記事の数.
@@ -181,7 +181,7 @@ wp_reset_postdata();
 							<?php
 							if ( $count === $posts_per_page ) :
 								?>
-							<div id="more"><a href="#" class="btn btn-primary btn-wide-sp">もっと見る</a></div>
+							<!-- <div id="more"><a href="#" class="btn btn-primary btn-wide-sp">もっと見る</a></div> -->
 							<?php endif; ?>
 						<?php else : // 記事が無い場合. ?>
 							<div><p>記事はまだありません。</p></div>


### PR DESCRIPTION
## 概要

0004＿0004TOPもっとみるボタンの追加
https://github.com/sakukei/rite/issues/6

## 変更内容

トップページのピックアップ一覧の「もっと見る」ボタンを削除して全件表示

## その他
- 
