### PR TITLE
トップページのピックアップ一覧のスマホ時のデザイン微調整

### DIFF
--- a/apps/wordpress/htdocs/wp-content/themes/welcart_basic-square/front-page.php
+++ b/apps/wordpress/htdocs/wp-content/themes/welcart_basic-square/front-page.php
@@ -156,7 +156,11 @@ wp_reset_postdata();
 											<div class="pickup-content-inner">
 												<p class="pickup-content-title"><?php the_title(); ?></p>
 												<div class="pickup-content-column">
+													<?php if ( wp_is_mobile() ) : ?>
+													<p class="pickup-content-lead"><?php echo wp_kses_post( wp_trim_words( get_the_content(), 36, '...' ) ); ?></p>
+													<?php else : ?>
 													<p class="pickup-content-lead"><?php echo wp_kses_post( wp_trim_words( get_the_content(), 50, '...' ) ); ?></p>
+													<?php endif; ?>
 													<div class="pickup-contributor">
 														<div class="pickup-contributor-column">
 															<div class="pickup-icon contributor-icon">

--- a/apps/wordpress/htdocs/wp-content/themes/welcart_basic-square/style.css
+++ b/apps/wordpress/htdocs/wp-content/themes/welcart_basic-square/style.css
@@ -1217,12 +1217,13 @@ footer nav a {
 
 .blog #content article.pickup-article {
   /*margin: 0 0 8px;*/
-  padding-bottom: 0;
+  padding-bottom: 62px;
 	border: none;
 	width: 49%;
 	padding-top: 0;
 	background: #fff;
 	margin-bottom: 10px;
+	position: relative;
 }
 
 @media screen and (min-width: 62.5em) {
@@ -1231,6 +1232,7 @@ footer nav a {
 		width: 100%;
 		background: transparent;
 		margin-bottom: 0;
+		padding-bottom: 0;
 	}
 
 	.blog #content article.pickup-article + .pickup-article {
@@ -1930,11 +1932,25 @@ p.no-date {
 }
 
 .pickup-content-inner {
-  padding: 20px 10px 10px;
+  padding: 20px 6px 10px;
+}
+
+@media screen and (min-width: 62.5em) {
+
+	.pickup-content-inner {
+		padding: 20px 10px 10px;
+	}
 }
 
 .pickup-content-title {
-  font-size: 16px;
+  font-size: 13px;
+}
+
+@media screen and (min-width: 62.5em) {
+
+	.pickup-content-title {
+		font-size: 16px;
+	}
 }
 
 .pickup-content-column {
@@ -1968,7 +1984,20 @@ p.no-date {
 }
 
 .pickup-contributor {
-  padding-top: 0;
+	padding-top: 0;
+	position: absolute;
+	bottom: 8px;
+	left: 0;
+	width: 100%;
+	display: block;
+}
+
+@media screen and (min-width: 62.5em) {
+
+	.pickup-contributor {
+		position: static;
+		width: auto;
+	}
 }
 
 .pickup-contributor-column {


### PR DESCRIPTION
## 概要

0004＿0003 TOPへの商品一覧・インフルエンサーページリンクの表示
https://github.com/sakukei/rite/issues/3

## 変更内容

トップページのピックアップ一覧のスマホ時のデザイン微調整
---
1. SP時のタイトルのテキストサイズ下げる 商品タイトルと同じさいずでいいです。

2.インフルエンサーのアイコンとインフルエンサー名を
パネルのdiv 下からの相対位置指定にする

3.文字の左右マージンを下げる

4.かなりwantだけど、本文ちらだしのテキスト数を少し下げる(SPのみ)
---

## その他
- 
