### PR TITLE
【急ぎ対応】GAのカスタムリンクをカートに入れるボタン押下時に飛ばす

### DIFF
--- a/apps/wordpress/htdocs/wp-content/plugins/usc-e-shop/functions/template_func.php
+++ b/apps/wordpress/htdocs/wp-content/plugins/usc-e-shop/functions/template_func.php
@@ -749,7 +749,7 @@ function usces_the_itemSkuButton($value, $type=0, $out = '') {
 	$html .= "<input name=\"gptekiyo[{$post_id}][{$sku}]\" type=\"hidden\" id=\"gptekiyo[{$post_id}][{$sku}]\" value=\"{$gptekiyo}\" />\n";
 	$html .= "<input name=\"skuPrice[{$post_id}][{$sku}]\" type=\"hidden\" id=\"skuPrice[{$post_id}][{$sku}]\" value=\"{$skuPrice}\" />\n";
 	if( $usces->use_js ){
-		$html .= "<input name=\"inCart[{$post_id}][{$sku}]\" type=\"{$type}\" id=\"inCart[{$post_id}][{$sku}]\" class=\"skubutton\" value=\"{$value}\" onclick=\"return uscesCart.intoCart('{$post_id}','{$sku}')\" />";
+        $html .= "<input name=\"inCart[{$post_id}][{$sku}]\" type=\"{$type}\" id=\"inCart[{$post_id}][{$sku}]\" class=\"skubutton js-cart\" value=\"{$value}\" onclick=\"return uscesCart.intoCart('{$post_id}','{$sku}')\" />";
 	}else{
 		$html .= "<a name=\"cart_button\"></a><input name=\"inCart[{$post_id}][{$sku}]\" type=\"{$type}\" id=\"inCart[{$post_id}][{$sku}]\" class=\"skubutton\" value=\"{$value}\" />";
 	}

--- a/apps/wordpress/htdocs/wp-content/themes/welcart_basic-square/js/script.js
+++ b/apps/wordpress/htdocs/wp-content/themes/welcart_basic-square/js/script.js
@@ -25,6 +25,14 @@ jQuery( function() {
 		});
 		return false;
 	});
+	jQuery('.js-cart').on('click',function(){
+		ga('send','event', {
+			eventCategory: 'Link',
+			eventAction: 'click',
+            eventLabel: location.href
+        });
+	});
 });
+
 
 


### PR DESCRIPTION
## 概要  
【急ぎ対応】GAのカスタムリンクをカートに入れるボタン押下時に飛ばす #45

## 変更内容  
.js-cartクラスを追加して押下されたらURLをカスタムリンクで飛ばす


ローカルにGAのコードがなかったのでそこだけ引っ張ってきて検証
![image](https://user-images.githubusercontent.com/30423583/49341658-21f38400-f694-11e8-8de1-206457e74f75.png)

