### PR TITLE
0004＿0004TOPもっとみるボタンの追加 #6

### DIFF
--- a/apps/wordpress/htdocs/wp-content/themes/welcart_basic-square/front-page.php
+++ b/apps/wordpress/htdocs/wp-content/themes/welcart_basic-square/front-page.php
@@ -131,7 +131,7 @@ wp_reset_postdata();
 						<p class="contents-title">ピックアップ</p>
 						<?php
 						$count          = 0;
-						$posts_per_page = -1; // 15
+						$posts_per_page = 15; // 15
 						$pickup_query   = new WP_Query(
 							array(
 								'posts_per_page' => $posts_per_page, // 表示（取得）する記事の数.
@@ -141,7 +141,7 @@ wp_reset_postdata();
 						?>
 						<?php
 						if ( $pickup_query->have_posts() ) : ?>
-						<div class="row row-0">
+						<div class="row row-0 js-pickupArticle">
 						<?php
 							while ( $pickup_query->have_posts() ) :
 								$pickup_query->the_post();
@@ -185,7 +185,7 @@ wp_reset_postdata();
 							<?php
 							if ( $count === $posts_per_page ) :
 								?>
-							<!-- <div id="more"><a href="#" class="btn btn-primary btn-wide-sp">もっと見る</a></div> -->
+							 <div id="more"><a href="#" class="btn btn-primary btn-wide-sp">もっと見る</a></div>
 							<?php endif; ?>
 						<?php else : // 記事が無い場合. ?>
 							<div><p>記事はまだありません。</p></div>

--- a/apps/wordpress/htdocs/wp-content/themes/welcart_basic-square/js/script.js
+++ b/apps/wordpress/htdocs/wp-content/themes/welcart_basic-square/js/script.js
@@ -1,9 +1,9 @@
 var nowPostNum = 15; // 現在表示されている数
 var getPostNum = 15; // 一度に取得する数
-var baseUrl = location.protocol + '//' + location.hostname + '/wp-content/themes/welcart_basic-square';
+var baseUrl = location.protocol + '//' + location.hostname + '/wp-content/themes/themes/welcart_basic-square';
 
 jQuery( function() {
-	jQuery( '#more a' ).live( 'click', function() {
+	jQuery( '#more a' ).on( 'click', function() {
 		jQuery( '#more' ).html( '<img class="ajax_loading" src="' + baseUrl + '/images/loading.gif" />' );
 
 		jQuery.ajax({
@@ -16,7 +16,7 @@ jQuery( function() {
 			success: function( data ) {
 				data = JSON.parse( data );
 				nowPostNum = nowPostNum + getPostNum;
-				jQuery( '.top-pickup' ).append( data.html );
+				jQuery( '.js-pickupArticle' ).append( data.html );
 				jQuery( '#more' ).remove();
 				if ( ! data.noDataFlg ) {
 					jQuery( '.top-pickup' ).append( '<div id="more"><p class="incart-btn"><a href="#" class="header-incart-btn"><span class="incart-btn-text">もっと見る</span></a></p></div>' );
@@ -32,6 +32,7 @@ jQuery( function() {
             eventLabel: location.href
         });
 	});
+
 });
 
 


### PR DESCRIPTION
## 概要
TOPのピックアップにもっとみるボタンを実装

## 変更内容
最初表示される記事の数を15に変更
もっとみるボタンを押された時に追加される記事の挿入位置を修正
（全部の記事を囲んでいるdivにjs-pickupArticleクラスを追加して、そこにapendで追加）

## その他
検品、本番環境で動くようにいったん
'/wp-content/themes/welcart_basic-square'
↓
'/wp-content/themes/themes/welcart_basic-square'
に修正