### PR TITLE
カテゴリーが取得できなくなっていたのを修正

### DIFF
--- a/apps/wordpress/htdocs/wp-content/themes/welcart_basic-square/functions.php
+++ b/apps/wordpress/htdocs/wp-content/themes/welcart_basic-square/functions.php
@@ -230,6 +230,7 @@ function get_category_name( $object ) {
   for ($i = 0; $i < count($category); ++$i) {
     $cat_name[$i] = $category[$i]->cat_name;
   }
+  return $cat_name;
 }
 
 //タグ名を取得する関数を登録


### PR DESCRIPTION
## 概要
- カテゴリーが取得できなくなっていたのを修正

- dev環境では商品にトラベラー名、fashionなどのカテゴリーが設定できていたので、これでTOP SPA部分のファッション、フード、トラベラーなどのところにも商品が出るはず